### PR TITLE
Bug fix

### DIFF
--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -15,42 +15,14 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_change
 from homeassistant.helpers.sun import get_astral_location
 
-DOMAIN = 'sun2'
-
-_DT_TYPES = {
-    'dawn': 'mdi:weather-sunset-up',
-    'dusk': 'mdi:weather-sunset-down',
-    'solar_noon': 'mdi:weather-sunny',
-    'sunrise': 'mdi:weather-sunset-up',
-    'sunset': 'mdi:weather-sunset-down',
-}
-
-_TD_TYPES = {
-    'daylight': 'mdi:weather-sunny',
-    'night': 'mdi:weather-night',
-}
-
-_SENSOR_TYPES = list(_DT_TYPES) + list(_TD_TYPES)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_MONITORED_CONDITIONS): vol.All(
-        cv.ensure_list, [vol.In(_SENSOR_TYPES)]),
-})
-
-
-async def async_setup_platform(
-        hass, config, async_add_entities, discovery_info=None):
-    """Set up sensors."""
-    async_add_entities([Sun2Sensor(event)
-                        for event in config[CONF_MONITORED_CONDITIONS]])
-
 
 class Sun2Sensor(Entity):
     """Sun2 Sensor."""
 
-    def __init__(self, event):
+    def __init__(self, event, icon):
         """Initialize sensor."""
         self._event = event
+        self._icon = icon
         self._location = None
         self._state = None
         self._yesterday = None
@@ -82,23 +54,9 @@ class Sun2Sensor(Entity):
         }
 
     @property
-    def device_class(self):
-        """Return the class of this device."""
-        if self._event in _DT_TYPES:
-            return DEVICE_CLASS_TIMESTAMP
-        return None
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        if self._event in _TD_TYPES:
-            return 'hr'
-        return None
-
-    @property
     def icon(self):
         """Return the icon to use in the frontend."""
-        return _DT_TYPES.get(self._event, _TD_TYPES.get(self._event))
+        return self._icon
 
     async def async_added_to_hass(self):
         """Set up sensor."""
@@ -118,23 +76,75 @@ class Sun2Sensor(Entity):
 
     def _get_astral_event(self, date):
         try:
-            result = getattr(self._location, self._event)(date)
+            self._location.solar_depression = 'civil'
+            return getattr(self._location, self._event)(date)
         except AstralError:
             return None
-        if self._event in _DT_TYPES:
-            return result
-        start, end = result
-        return (end - start).total_seconds()/3600
+
+    def _async_update(self):
+        today = dt_util.now().date()
+        self._yesterday = self._get_astral_event(today-timedelta(days=1))
+        self._state = self._today = self._get_astral_event(today)
+        self._tomorrow = self._get_astral_event(today+timedelta(days=1))
 
     async def async_update(self):
         """Update state."""
-        today = dt_util.now().date()
-        self._yesterday = self._get_astral_event(today-timedelta(days=1))
-        self._today = self._get_astral_event(today)
-        self._tomorrow = self._get_astral_event(today+timedelta(days=1))
-        if self._today is None:
-            self._state = None
-        elif self._event in _DT_TYPES:
-            self._state = self._today.isoformat()
-        else:
-            self._state = round(self._today, 3)
+        self._async_update()
+
+
+class Sun2Datetime(Sun2Sensor):
+    """Sun2 datetime Sensor."""
+
+    @property
+    def device_class(self):
+        """Return the class of this device."""
+        return DEVICE_CLASS_TIMESTAMP
+
+    def _async_update(self):
+        super()._async_update()
+        if self._state is not None:
+            self._state = self._state.isoformat()
+
+
+class Sun2Hours(Sun2Sensor):
+    """Sun2 Hours Sensor."""
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return 'hr'
+
+    def _get_astral_event(self, date):
+        result = super()._get_astral_event(date)
+        if result is None:
+            return None
+        start, end = result
+        return (end - start).total_seconds()/3600
+
+    def _async_update(self):
+        super()._async_update()
+        if self._state is not None:
+            self._state = round(self._state, 3)
+
+
+_SENSOR_TYPES = {
+    'dawn': (Sun2Datetime, 'mdi:weather-sunset-up'),
+    'daylight': (Sun2Hours, 'mdi:weather-sunny'),
+    'dusk': (Sun2Datetime, 'mdi:weather-sunset-down'),
+    'night': (Sun2Hours, 'mdi:weather-night'),
+    'solar_noon': (Sun2Datetime, 'mdi:weather-sunny'),
+    'sunrise': (Sun2Datetime, 'mdi:weather-sunset-up'),
+    'sunset': (Sun2Datetime, 'mdi:weather-sunset-down'),
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_CONDITIONS): vol.All(
+        cv.ensure_list, [vol.In(_SENSOR_TYPES)]),
+})
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up sensors."""
+    async_add_entities([_SENSOR_TYPES[event][0](event, _SENSOR_TYPES[event][1])
+                        for event in config[CONF_MONITORED_CONDITIONS]])

--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -118,12 +118,13 @@ class Sun2Sensor(Entity):
 
     def _get_astral_event(self, date):
         try:
-            if self._event in _DT_TYPES:
-                return getattr(self._location, self._event)(date)
-            start, end = getattr(self._location, self._event)(date)
-            return (end - start).total_seconds()/3600
+            result = getattr(self._location, self._event)(date)
         except AstralError:
-            return 'none'
+            return None
+        if self._event in _DT_TYPES:
+            return result
+        start, end = result
+        return (end - start).total_seconds()/3600
 
     async def async_update(self):
         """Update state."""
@@ -131,7 +132,9 @@ class Sun2Sensor(Entity):
         self._yesterday = self._get_astral_event(today-timedelta(days=1))
         self._today = self._get_astral_event(today)
         self._tomorrow = self._get_astral_event(today+timedelta(days=1))
-        if self._event in _DT_TYPES:
+        if self._today is None:
+            self._state = None
+        elif self._event in _DT_TYPES:
             self._state = self._today.isoformat()
         else:
             self._state = round(self._today, 3)


### PR DESCRIPTION
Some sensors (such as dawn & dusk) were not returning correct values. Apparently astral's Location.solar_depression needs to be explicitly set to 'civil' for its functions to return expected values.

Also reorganize code (mostly class definitions) to make it easier in the future to add sensor types that need to adjust some of the existing behavior (e.g., elevation.)

Lastly, improve error handling a bit.