### PR TITLE
astral package updated to 2.2

### DIFF
--- a/custom_components/sun2/helpers.py
+++ b/custom_components/sun2/helpers.py
@@ -1,6 +1,10 @@
 """Sun2 Helpers."""
 from datetime import timedelta
 
+try:
+    from astral import AstralError
+except ImportError:
+    AstralError = TypeError
 from homeassistant.const import EVENT_CORE_CONFIG_UPDATE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -9,28 +13,45 @@ from homeassistant.helpers.sun import get_astral_location
 SIG_LOC_UPDATED = 'sun2_loc_updated'
 
 _LOC = None
+_ELEV = None
 _HASS = None
+
+def _get_astral_location():
+    global _LOC, _ELEV
+    try:
+        _LOC, _ELEV = get_astral_location(_HASS)
+    except TypeError:
+        _LOC = get_astral_location(_HASS)
 
 
 def _update_location(event):
-    global _LOC
-    _LOC = get_astral_location(_HASS)
+    _get_astral_location()
     dispatcher_send(_HASS, SIG_LOC_UPDATED)
 
 
 @callback
 def async_init_astral_loc(hass):
     """Initialize astral Location."""
-    global _LOC, _HASS
+    global _HASS
     if not _LOC:
         _HASS = hass
-        _LOC = get_astral_location(hass)
+        _get_astral_location()
         hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, _update_location)
 
 
-def astral_loc():
-    """Return astral Location."""
-    return _LOC
+def astral_event(event, date_or_dt, depression=None):
+    """Return astral event result."""
+    if depression is not None:
+        _LOC.solar_depression = depression
+    try:
+        if _ELEV is not None:
+            if event in ('solar_midnight', 'solar_noon'):
+                return getattr(_LOC, event.replace('solar_', ''))(date_or_dt)
+            else:
+                return getattr(_LOC, event)(date_or_dt, observer_elevation=_ELEV)
+        return getattr(_LOC, event)(date_or_dt)
+    except AstralError:
+        return 'none'
 
 
 def nearest_second(time):


### PR DESCRIPTION
Per [HA PR #48573](https://github.com/home-assistant/core/pull/48573), the astral package used by HA will be changing from 1.10.1 to 2.2. (Presumably this will be in the 2021.4 release.) The API of both that package, and `homeassistant.helpers.sun`, change significantly, breaking this custom integration. This change fixes that problem, while maintaining compatibility with older versions of HA. Fixes #32.