### PR TITLE
Properly handle ValueError from astral package

### DIFF
--- a/custom_components/sun2/helpers.py
+++ b/custom_components/sun2/helpers.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 try:
     from astral import AstralError
 except ImportError:
-    AstralError = TypeError
+    AstralError = (TypeError, ValueError)
 from homeassistant.const import EVENT_CORE_CONFIG_UPDATE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import dispatcher_send


### PR DESCRIPTION
astral package used to throw its own AstralError, but now can throw TypeError or ValueError. Was only handling TypeError.

Closes #42