### PR TITLE
Handle new time zone type in HA core

### DIFF
--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -40,7 +40,7 @@ ATTR_NEXT_CHANGE = "next_change"
 
 
 def next_midnight(dt):
-    return dt.tzinfo.localize(datetime.combine(dt.date() + _ONE_DAY, time()))
+    return datetime.combine(dt.date() + _ONE_DAY, time(), dt.tzinfo)
 
 
 class Sun2Sensor(Entity):


### PR DESCRIPTION
HA 2021.6.x changed how time zones are handled, specifically changing from pytz to Python's new native zoneinfo. This change adjusts accordingly.  Fixes #46.