### PR TITLE
Fix device_state_attributes warnings

### DIFF
--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -103,7 +103,7 @@ class Sun2Sensor(Entity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return self._device_state_attributes()
 


### PR DESCRIPTION
Home Assistant 2021.12 warns that various Sun2 sensors implement `device_state_attributes`.

This results from the move from sensor property `device_state_attributes` to `extra_state_attributes`. All affected sensors extend class `Sun2Sensor`, so renaming `device_state_attributes` to `extra_state_attributes` for this class fixes the error.

Links to this issue: #52