### PR TITLE
Fix device_state_attributes warnings

### DIFF
--- a/custom_components/sun2/binary_sensor.py
+++ b/custom_components/sun2/binary_sensor.py
@@ -160,7 +160,7 @@ class Sun2ElevationSensor(BinarySensorEntity):
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return {ATTR_NEXT_CHANGE: self._next_change}
 

--- a/custom_components/sun2/manifest.json
+++ b/custom_components/sun2/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sun2",
   "name": "Sun2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "documentation": "https://github.com/pnbruckner/ha-sun2/blob/master/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-sun2/issues",
   "requirements": [],

--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -313,7 +313,7 @@ class Sun2ElevationSensor(Sun2Sensor):
         self._next_change = None
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return {ATTR_NEXT_CHANGE: self._next_change}
 

--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -103,7 +103,7 @@ class Sun2Sensor(Entity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return self._device_state_attributes()
 


### PR DESCRIPTION
Home Assistant 2021.12 warns that various Sun2 sensors implement `device_state_attributes`.

This results from the move from sensor property `device_state_attributes` to `extra_state_attributes`. All affected sensors extend classes `Sun2Sensor` and `Sun2ElevationSensor`, so renaming `device_state_attributes` to `extra_state_attributes` for these class fixes the error.

Ditto for binary sensors.

Version bumped to 2.0.3

Links to this issue: #52