### PR TITLE
Handle Entity property name change & bump to 2.0.3

### DIFF
--- a/custom_components/sun2/binary_sensor.py
+++ b/custom_components/sun2/binary_sensor.py
@@ -19,6 +19,8 @@ from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     CONF_NAME,
     CONF_TIME_ZONE,
+    MAJOR_VERSION,
+    MINOR_VERSION,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
@@ -159,10 +161,19 @@ class Sun2ElevationSensor(BinarySensorEntity):
         """Return the name of the entity."""
         return self._name
 
-    @property
-    def device_state_attributes(self):
-        """Return device specific state attributes."""
+    def _device_state_attributes(self):
         return {ATTR_NEXT_CHANGE: self._next_change}
+
+    if MAJOR_VERSION < 2021 or MAJOR_VERSION == 2021 and MINOR_VERSION < 4:
+        @property
+        def device_state_attributes(self):
+            """Return device specific state attributes."""
+            return self._device_state_attributes()
+    else:
+        @property
+        def extra_state_attributes(self):
+            """Return device specific state attributes."""
+            return self._device_state_attributes()
 
     @property
     def icon(self):

--- a/custom_components/sun2/manifest.json
+++ b/custom_components/sun2/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sun2",
   "name": "Sun2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "documentation": "https://github.com/pnbruckner/ha-sun2/blob/master/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-sun2/issues",
   "requirements": [],

--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -320,9 +320,7 @@ class Sun2ElevationSensor(Sun2Sensor):
         self._prv_elev = None
         self._next_change = None
 
-    @property
-    def device_state_attributes(self):
-        """Return device specific state attributes."""
+    def _device_state_attributes(self):
         return {ATTR_NEXT_CHANGE: self._next_change}
 
     @property

--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -12,6 +12,8 @@ from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     CONF_TIME_ZONE,
     DEVICE_CLASS_TIMESTAMP,
+    MAJOR_VERSION,
+    MINOR_VERSION,
 )
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
@@ -102,10 +104,16 @@ class Sun2Sensor(Entity):
             "tomorrow": self._tomorrow,
         }
 
-    @property
-    def device_state_attributes(self):
-        """Return device specific state attributes."""
-        return self._device_state_attributes()
+    if MAJOR_VERSION < 2021 or MAJOR_VERSION == 2021 and MINOR_VERSION < 4:
+        @property
+        def device_state_attributes(self):
+            """Return device specific state attributes."""
+            return self._device_state_attributes()
+    else:
+        @property
+        def extra_state_attributes(self):
+            """Return device specific state attributes."""
+            return self._device_state_attributes()
 
     @property
     def icon(self):


### PR DESCRIPTION
Starting with HA 2021.4 the Entity property device_state_attributes has been renamed to extra_state_attributes. This change supports the new name, as well as continues to support the old name for backwards compatibility. Fixes #52.