### PR TITLE
Fix rising & blue hour attributes

### DIFF
--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -668,7 +668,7 @@ class Sun2PhaseSensor(Sun2PhaseSensorBase):
             golden_hour = -4 < elev <= 6
         attrs[ATTR_BLUE_HOUR] = blue_hour
         attrs[ATTR_GOLDEN_HOUR] = golden_hour
-        attrs[ATTR_BLUE_HOUR] = self._p.rising
+        attrs[ATTR_RISING] = self._p.rising
         return attrs
 
 


### PR DESCRIPTION
Typo caused rising attribute to be missing and blue hour attribute to be wrong. Fixes #63.