### PR TITLE
Fix elevation estimate failures for sun phase sensor

### DIFF
--- a/custom_components/sun2/manifest.json
+++ b/custom_components/sun2/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sun2",
   "name": "Sun2",
-  "version": "2.1.2",
+  "version": "2.1.3b0",
   "documentation": "https://github.com/pnbruckner/ha-sun2/blob/master/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-sun2/issues",
   "requirements": [],


### PR DESCRIPTION
In some circumstances, calculating when updates should occur for phase sensors failed. This change attempts to handle those cases properly.

Fixes #68.

Basically, astral's time_at_elevation is used to get an initial estimate of when the sun will be at a certain elevation. In some cases, the returned value is actually for the day before (or after) the time period of interest (i.e., [tL, tR).) So, the change checks for this, and if it occurs, tries again, but using a date that is one day earlier or later, as appropriate. If it still fails, it will give up and fall back, just like when time_at_elevation itself fails to find a time at all.