### PR TITLE
Do not change point-in-time sensor state from None/unknown to 'none'

### DIFF
--- a/custom_components/sun2/sensor.py
+++ b/custom_components/sun2/sensor.py
@@ -174,14 +174,6 @@ class Sun2PointInTimeSensor(Sun2SensorEntity[Union[datetime, str]]):
         )
         super().__init__(loc_params, namespace, entity_description, "civil")
 
-    def _update(self, cur_dttm: datetime) -> None:
-        """Update state."""
-        super()._update(cur_dttm)
-        # A state of None will get converted to "unknown", which is not appropriate for
-        # this sensor. Use the word "none" instead.
-        if self._attr_native_value is None:
-            self._attr_native_value = "none"
-
 
 class Sun2PeriodOfTimeSensor(Sun2SensorEntity[float]):
     """Sun2 Period of Time Sensor."""


### PR DESCRIPTION
Fixes #82

Possibly as far back as 2021.12, the string value of "none" is not allowed for a sensor entity that has a device class of timestamp. This will cause an exception. This change leaves the value as None (which results in "unknown", instead of changing it to the invalid value of "none".)