### PR TITLE
Add azimuth sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ type | description
 #### Other Sensors
 type | description
 -|-
+`azimuth` | The sun's azimuth (degrees).
 `elevation` | The sun's elevation (degrees).
 `min_elevation` | The sun's elevation at solar midnight (degrees).
 `max_elevation` | The sun's elevation at solar noon (degrees).
@@ -201,6 +202,7 @@ sensor:
       - civil_night
       - nautical_night
       - astronomical_night
+      - azimuth
       - elevation
       - min_elevation
       - max_elevation

--- a/custom_components/sun2/manifest.json
+++ b/custom_components/sun2/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/pnbruckner/ha-sun2/issues",
   "requirements": [],
-  "version": "2.3.1"
+  "version": "2.4.0b0"
 }


### PR DESCRIPTION
Add basic azimuth sensor, which is functionally equivalent to the built-in sun integration's implementation. I.e., its update period changes based on current elevation.

Closes #25.