### PR TITLE
Use UTC datetimes internally

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,2 @@
+"""Sun2 integration."""
+# Exists to satisfy mypy.

--- a/custom_components/sun2/config.py
+++ b/custom_components/sun2/config.py
@@ -42,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 _COERCE_NUM = vol.Any(vol.Coerce(int), vol.Coerce(float))
 
 PACKAGE_MERGE_HINT = "list"
-SUN_DIRECTIONS = [dir.lower() for dir in SunDirection.__members__]
+SUN_DIRECTIONS = [sd.lower() for sd in SunDirection.__members__]
 SUN2_LOCATION_BASE_SCHEMA = vol.Schema(
     {
         vol.Inclusive(CONF_LATITUDE, "location"): cv.latitude,
@@ -157,19 +157,19 @@ def obs_elv_from_options(
     if obs_elv_option := options.get(CONF_OBS_ELV):
         east_obs_elv, west_obs_elv = obs_elv_option
 
-        if isinstance(east_obs_elv, Num) and isinstance(west_obs_elv, Num):  # type: ignore[misc, arg-type]
+        if isinstance(east_obs_elv, Num) and isinstance(west_obs_elv, Num):
             assert east_obs_elv == west_obs_elv
             return cast(Num, east_obs_elv)
 
         obs_elv: ConfigType = {}
-        if isinstance(east_obs_elv, Num):  # type: ignore[misc, arg-type]
+        if isinstance(east_obs_elv, Num):
             obs_elv[CONF_ABOVE_GROUND] = east_obs_elv
         else:
             obs_elv[CONF_SUNRISE_OBSTRUCTION] = {
                 CONF_DISTANCE: east_obs_elv[1],
                 CONF_RELATIVE_HEIGHT: east_obs_elv[0],
             }
-        if isinstance(west_obs_elv, Num):  # type: ignore[misc, arg-type]
+        if isinstance(west_obs_elv, Num):
             obs_elv[CONF_ABOVE_GROUND] = west_obs_elv
         else:
             obs_elv[CONF_SUNSET_OBSTRUCTION] = {
@@ -230,7 +230,7 @@ def options_from_obs_elv(
             )
             east_obs_elv = west_obs_elv = hass.config.elevation
 
-        elif isinstance(obs := loc_config[CONF_OBS_ELV], Num):  # type: ignore[misc, arg-type]
+        elif isinstance(obs := loc_config[CONF_OBS_ELV], Num):
             east_obs_elv = west_obs_elv = obs
 
         else:

--- a/custom_components/sun2/config_flow.py
+++ b/custom_components/sun2/config_flow.py
@@ -255,8 +255,8 @@ class Sun2Flow(FlowHandler):
 
         if obs_elv := self.options.get(CONF_OBS_ELV):
             suggested_values = {
-                CONF_SUNRISE_OBSTRUCTION: not isinstance(obs_elv[0], Num),  # type: ignore[misc, arg-type]
-                CONF_SUNSET_OBSTRUCTION: not isinstance(obs_elv[1], Num),  # type: ignore[misc, arg-type]
+                CONF_SUNRISE_OBSTRUCTION: not isinstance(obs_elv[0], Num),
+                CONF_SUNSET_OBSTRUCTION: not isinstance(obs_elv[1], Num),
             }
         else:
             suggested_values = {
@@ -297,7 +297,7 @@ class Sun2Flow(FlowHandler):
                 self.options[CONF_ELEVATION] = above_ground
             return await self.async_step_entities_menu()
 
-        schema: dict[str, Any] = {}
+        schema: dict[vol.Schemable, Any] = {}
         if get_above_ground:
             schema[vol.Required(CONF_ABOVE_GROUND)] = _POSITIVE_METERS_SELECTOR
         if self._sunrise_obstruction:
@@ -312,11 +312,11 @@ class Sun2Flow(FlowHandler):
         sunrise_distance = sunset_distance = 1000
         sunrise_relative_height = sunset_relative_height = 1000
         if obs_elv := self.options.get(CONF_OBS_ELV):
-            if isinstance(obs_elv[0], Num):  # type: ignore[misc, arg-type]
+            if isinstance(obs_elv[0], Num):
                 above_ground = obs_elv[0]
             else:
                 sunrise_relative_height, sunrise_distance = obs_elv[0]
-            if isinstance(obs_elv[1], Num):  # type: ignore[misc, arg-type]
+            if isinstance(obs_elv[1], Num):
                 # If both directions use above_ground, they should be the same.
                 # Assume this is true and don't bother checking here.
                 above_ground = obs_elv[1]

--- a/custom_components/sun2/manifest.json
+++ b/custom_components/sun2/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/pnbruckner/ha-sun2/blob/3.3.4/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-sun2/blob/3.3.5b0/README.md",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/pnbruckner/ha-sun2/issues",
   "requirements": [],
-  "version": "3.3.4"
+  "version": "3.3.5b0"
 }


### PR DESCRIPTION
Python datetime object comparisons and math don't work as expected when the objects are aware and have the same tzinfo attribute. Basically, the fold attribute is ignored in this case, which can lead to wrong results.

Avoid this problem by using aware times in UTC internally. Only use local time zone for user visible attributes.